### PR TITLE
fix: update permissions in GitHub Actions workflow to allow write 

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
access for contents

## Summary by Sourcery

CI:
- Modify workflow permissions to enable write access for contents and pull requests