### PR TITLE
fix: clean url broken in hero page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
         "encriptación",
         "enrutación",
         "enrutamiento",
+        "Epam",
         "escalabilidad",
         "flutterdart",
         "linkedin",

--- a/src/content/docs/es/index.mdx
+++ b/src/content/docs/es/index.mdx
@@ -20,9 +20,6 @@ hero:
       link: skills/angular/
       icon: right-arrow
       variant: primary
-    - text: Blog
-      link: blog
-      icon: external
 lastUpdated: false
 editUrl: false
 ---

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -20,9 +20,6 @@ hero:
       link: skills/angular/
       icon: right-arrow
       variant: primary
-    - text: Blog
-      link: blog
-      icon: external
 lastUpdated: false
 editUrl: false
 ---


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Removed broken blog link from hero section in both English and Spanish index pages