### PR TITLE
build: add 'sharp' to onlyBuiltDependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,5 +18,6 @@ onlyBuiltDependencies:
   # Runtime helpers
   - '@swc/helpers'
   - '@babel/runtime'
+  - 'sharp'
   # Types
   - '@types/node'


### PR DESCRIPTION
The 'sharp' library is added to the onlyBuiltDependencies list in the pnpm-workspace.yaml file to ensure it is included in the build process, as it is required for runtime operations.