### PR TITLE
docs(CONTRIBUTORS): fix grammar and update emoji key link

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-Thanks goes to all of these wonderful people (emoji key) who have helped Sign Tech Interview get this far:
+Thanks go to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)) who have helped Sign Tech Interview get this far:
 
 
 <!-- [![Contributors](https://contrib.rocks/image?repo=signlanguagetech/crack-interview)](https://github.com/signlanguagetech/crack-interview/graphs/contributors) -->


### PR DESCRIPTION
Correct the grammar from "Thanks goes to" to "Thanks go to" and update the emoji key link to the correct URL

## Summary by Sourcery

Update CONTRIBUTORS.md to correct grammar and add the emoji key link.

Documentation:
- Correct grammar in the introductory sentence.
- Add the link to the emoji key definition.