### PR TITLE
Refactor/updated path pagetitle

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-Thanks goes to all of these wonderful people (emoji key) who have helped Sign Tech Interview get this far:
+Thanks go to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)) who have helped Sign Tech Interview get this far:
 
 
 <!-- [![Contributors](https://contrib.rocks/image?repo=signlanguagetech/crack-interview)](https://github.com/signlanguagetech/crack-interview/graphs/contributors) -->

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -73,7 +73,7 @@ export default defineConfig({
         './src/styles/custom.css',
       ],
       components: {
-        PageTitle: './src/components/PageTitle.astro',
+        PageTitle: './src/components/overrides/PageTitle.astro',
         Footer: './src/components/overrides/Footer.astro',
         Head: './src/components/overrides/Head.astro'
       },

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -1,7 +1,7 @@
 ---
 import PageTitleBase from '@astrojs/starlight/components/PageTitle.astro';
 import LastUpdatedBase from '@astrojs/starlight/components/LastUpdated.astro';
-import AuthorProfile from './AuthorProfile.astro';
+import AuthorProfile from '../AuthorProfile.astro';
 
 const { authors } = Astro.locals.starlightRoute.entry.data;
 ---


### PR DESCRIPTION
## Summary by Sourcery

Relocate the custom `PageTitle` component to the `overrides` directory and update its configuration and imports.

Enhancements:
- Update the path for the custom `PageTitle` component in the Astro configuration.
- Adjust the import path for `AuthorProfile` within the moved `PageTitle` component.

Documentation:
- Update phrasing and add an emoji key link in `CONTRIBUTORS.md`.

Chores:
- Remove trailing newline from `CONTRIBUTORS.md`.