### PR TITLE
feat(docs): add YouTubeEmbed component to Angular skills page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -75,7 +75,8 @@ export default defineConfig({
       components: {
         PageTitle: './src/components/overrides/PageTitle.astro',
         Footer: './src/components/overrides/Footer.astro',
-        Head: './src/components/overrides/Head.astro'
+        Head: './src/components/overrides/Head.astro',
+        MarkdownContent: './src/components/overrides/MarkdownContent.astro',
       },
       head: [
         {

--- a/src/components/YouTubeEmbed.astro
+++ b/src/components/YouTubeEmbed.astro
@@ -1,4 +1,22 @@
 ---
+/**
+ * YouTubeEmbed component for embedding YouTube videos
+ *
+ * @param {string} videoId - The ID of the YouTube video
+ * @param {string} [title="YouTube video player"] - The title of the video player
+ * @param {number|string} [width=560] - The width of the video player
+ * @param {number|string} [height=315] - The height of the video player
+ * @param {boolean} [autoplay=false] - Whether to autoplay the video
+ * @param {boolean} [controls=true] - Whether to show the video controls
+ * @param {boolean} [showInfo=true] - Whether to show the video title and uploader
+ * @param {boolean} [rel=false] - Whether to show related videos at the end of the video
+ * @example
+ * ```mdx
+ * import YouTubeEmbed from '../../../../components/YouTubeEmbed.astro';
+ *
+ * <YouTubeEmbed videoId="u9RKE-aN3ac" />
+ * ```
+ */
 interface Props {
   videoId: string;
   title?: string;

--- a/src/components/YouTubeEmbed.astro
+++ b/src/components/YouTubeEmbed.astro
@@ -1,0 +1,72 @@
+---
+interface Props {
+  videoId: string;
+  title?: string;
+  width?: number | string;
+  height?: number | string;
+  autoplay?: boolean;
+  controls?: boolean;
+  showInfo?: boolean;
+  rel?: boolean;
+  loop?: boolean;
+  startAt?: number;
+}
+
+const {
+  videoId,
+  title = "YouTube video player",
+  width = 560,
+  height = 315,
+  autoplay = false,
+  controls = true,
+  showInfo = true,
+  rel = false,
+  loop = false,
+  startAt = 0,
+} = Astro.props;
+
+// Build the YouTube URL with parameters
+let youtubeUrl = `https://www.youtube.com/embed/${videoId}?`;
+const params = new URLSearchParams({
+  autoplay: autoplay ? "1" : "0",
+  controls: controls ? "1" : "0",
+  showinfo: showInfo ? "1" : "0",
+  rel: rel ? "1" : "0",
+  loop: loop ? "1" : "0",
+});
+
+if (startAt > 0) {
+  params.append("start", startAt.toString());
+}
+
+youtubeUrl += params.toString();
+---
+<div class="youtube-embed-container sticky">
+  <iframe
+    src={youtubeUrl}
+    title={title}
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen
+  ></iframe>
+</div>
+
+<style>
+  .youtube-embed-container iframe {
+    border: 0;
+    aspect-ratio: 16/9;
+    width: 100%;
+  }
+
+  div.sticky {
+    position: sticky;
+    top: 64px;
+  }
+
+  @media (max-width: 768px) {
+    div.sticky {
+      top: 112px;
+    }
+  }
+</style>

--- a/src/components/YouTubeEmbed.astro
+++ b/src/components/YouTubeEmbed.astro
@@ -1,16 +1,6 @@
 ---
 /**
  * YouTubeEmbed component for embedding YouTube videos
- *
- * @param {string} videoId - The ID of the YouTube video
- * @param {string} [title="YouTube video player"] - The title of the video player
- * @param {number|string} [width=560] - The width of the video player
- * @param {number|string} [height=315] - The height of the video player
- * @param {boolean} [autoplay=false] - Whether to autoplay the video
- * @param {boolean} [controls=true] - Whether to show the video controls
- * @param {boolean} [showInfo=true] - Whether to show the video title and uploader
- * @param {boolean} [rel=false] - Whether to show related videos at the end of the video
- * @example
  * ```mdx
  * import YouTubeEmbed from '../../../../components/YouTubeEmbed.astro';
  *
@@ -20,8 +10,6 @@
 interface Props {
   videoId: string;
   title?: string;
-  width?: number | string;
-  height?: number | string;
   autoplay?: boolean;
   controls?: boolean;
   showInfo?: boolean;
@@ -33,8 +21,6 @@ interface Props {
 const {
   videoId,
   title = "YouTube video player",
-  width = 560,
-  height = 315,
   autoplay = false,
   controls = true,
   showInfo = true,
@@ -43,7 +29,6 @@ const {
   startAt = 0,
 } = Astro.props;
 
-// Build the YouTube URL with parameters
 let youtubeUrl = `https://www.youtube.com/embed/${videoId}?`;
 const params = new URLSearchParams({
   autoplay: autoplay ? "1" : "0",

--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -4,7 +4,7 @@ import MarkdownContentBase from "@astrojs/starlight/components/MarkdownContent.a
 const { heroVideoUrl } = Astro.locals.starlightRoute.entry.data;
 import YouTubeEmbed from "../YouTubeEmbed.astro";
 ---
-{heroVideoUrl && heroVideoUrl !== "" && <YouTubeEmbed videoId={heroVideoUrl} />}
+{heroVideoUrl && <YouTubeEmbed videoId={heroVideoUrl} />}
 
 <MarkdownContentBase>
   <slot />

--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -6,7 +6,6 @@ import YouTubeEmbed from "../YouTubeEmbed.astro";
 ---
 {heroVideoUrl && <YouTubeEmbed videoId={heroVideoUrl} />}
 
-<pre>{JSON.stringify(Astro.locals.starlightRoute.entry.data, null, 2)}</pre>
 <MarkdownContentBase>
   <slot />
 </MarkdownContentBase>

--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -1,0 +1,12 @@
+---
+import MarkdownContentBase from "@astrojs/starlight/components/MarkdownContent.astro";
+
+const { heroVideoUrl } = Astro.locals.starlightRoute.entry.data;
+import YouTubeEmbed from "../YouTubeEmbed.astro";
+---
+{heroVideoUrl && heroVideoUrl !== "" && <YouTubeEmbed videoId={heroVideoUrl} />}
+
+<MarkdownContentBase>
+  <slot />
+  <MarkdownContentBase />
+</MarkdownContentBase>

--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -6,7 +6,7 @@ import YouTubeEmbed from "../YouTubeEmbed.astro";
 ---
 {heroVideoUrl && <YouTubeEmbed videoId={heroVideoUrl} />}
 
+<pre>{JSON.stringify(Astro.locals.starlightRoute.entry.data, null, 2)}</pre>
 <MarkdownContentBase>
   <slot />
-  <MarkdownContentBase />
 </MarkdownContentBase>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -16,7 +16,8 @@ export const collections = {
       extend: z.object({
         sltContent: z.boolean().default(true),
         authors: z.array(authorSchema).nonempty(),
-        tags: z.array(z.string().min(1)).optional()
+        tags: z.array(z.string().min(1)).optional(),
+        heroVideoUrl: z.string().regex(/^[A-Za-z0-9_-]{11}$/, "Must be a valid YouTube video ID").optional(),
       }),
     }),
   }),

--- a/src/content/docs/skills/Angular/index.mdx
+++ b/src/content/docs/skills/Angular/index.mdx
@@ -7,7 +7,7 @@ authors:
     title: Lead Software Engineer at Epam
     picture: https://avatars.githubusercontent.com/u/16865649?v=4&s=200
     url: https://signlanguagetech.com/
-heroVideoUrl: u9RKE-aN3ac
+# heroVideoUrl: u9RKE-aN3ac
 ---
 ## Crucial Topics
 

--- a/src/content/docs/skills/Angular/index.mdx
+++ b/src/content/docs/skills/Angular/index.mdx
@@ -8,6 +8,11 @@ authors:
     picture: https://avatars.githubusercontent.com/u/16865649?v=4&s=200
     url: https://signlanguagetech.com/
 ---
+
+import YouTubeEmbed from '../../../../components/YouTubeEmbed.astro';
+
+<YouTubeEmbed videoId="u9RKE-aN3ac" />
+
 ## Crucial Topics
 
 ### What is the difference between component and directive?

--- a/src/content/docs/skills/Angular/index.mdx
+++ b/src/content/docs/skills/Angular/index.mdx
@@ -7,12 +7,8 @@ authors:
     title: Lead Software Engineer at Epam
     picture: https://avatars.githubusercontent.com/u/16865649?v=4&s=200
     url: https://signlanguagetech.com/
+heroVideoUrl: u9RKE-aN3ac
 ---
-
-import YouTubeEmbed from '../../../../components/YouTubeEmbed.astro';
-
-<YouTubeEmbed videoId="u9RKE-aN3ac" />
-
 ## Crucial Topics
 
 ### What is the difference between component and directive?

--- a/src/content/docs/skills/NodeJs/index.mdx
+++ b/src/content/docs/skills/NodeJs/index.mdx
@@ -7,6 +7,7 @@ authors:
     title: Lead Software Engineer at Epam
     picture: https://avatars.githubusercontent.com/u/16865649?v=4&s=200
     url: https://signlanguagetech.com/
+heroVideoUrl: u9RKE-aN3ac
 ---
 
 # Node.js Interview Preparation

--- a/src/content/docs/skills/NodeJs/index.mdx
+++ b/src/content/docs/skills/NodeJs/index.mdx
@@ -7,7 +7,7 @@ authors:
     title: Lead Software Engineer at Epam
     picture: https://avatars.githubusercontent.com/u/16865649?v=4&s=200
     url: https://signlanguagetech.com/
-heroVideoUrl: u9RKE-aN3ac
+# heroVideoUrl: u9RKE-aN3ac
 ---
 
 # Node.js Interview Preparation


### PR DESCRIPTION
Introduce a new YouTubeEmbed component to embed YouTube videos in the Angular skills documentation. This enhances the learning experience by providing visual content alongside the text.

## Summary by Sourcery

Add a reusable component to embed YouTube videos and utilize it in the Angular skills documentation.

New Features:
- Introduce the `YouTubeEmbed` Astro component to embed YouTube videos with configurable parameters.

Documentation:
- Embed a relevant YouTube video on the Angular skills page.