### PR TITLE
Add yt video

### DIFF
--- a/src/content/docs/skills/Angular/index.mdx
+++ b/src/content/docs/skills/Angular/index.mdx
@@ -7,7 +7,7 @@ authors:
     title: Lead Software Engineer at Epam
     picture: https://avatars.githubusercontent.com/u/16865649?v=4&s=200
     url: https://signlanguagetech.com/
-# heroVideoUrl: u9RKE-aN3ac
+heroVideoUrl: FRCiqnFLvyg
 ---
 ## Crucial Topics
 

--- a/src/content/docs/skills/NodeJs/index.mdx
+++ b/src/content/docs/skills/NodeJs/index.mdx
@@ -7,7 +7,7 @@ authors:
     title: Lead Software Engineer at Epam
     picture: https://avatars.githubusercontent.com/u/16865649?v=4&s=200
     url: https://signlanguagetech.com/
-# heroVideoUrl: u9RKE-aN3ac
+heroVideoUrl: gteEgvBQOrw
 ---
 
 # Node.js Interview Preparation


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Replace hero video URLs for Angular and Node.js skill documentation pages