### PR TITLE
fix: update YTVideoId for Flutter interview questions

### DIFF
--- a/src/content/docs/es/skills/Flutter/index.mdx
+++ b/src/content/docs/es/skills/Flutter/index.mdx
@@ -7,7 +7,7 @@ authors:
     title: Flutter Developer
     picture: https://avatars.githubusercontent.com/u/19521054?v=4&s=200
     url: https://tech-andgar.me
-YTVideoId: DT4X_gCH-qs
+YTVideoId: BT2oZELyZK0
 ---
 
 - [Términos técnicos TLDR](#términos-técnicos-tldr)

--- a/src/content/docs/skills/Flutter/index.mdx
+++ b/src/content/docs/skills/Flutter/index.mdx
@@ -7,7 +7,7 @@ authors:
     title: Flutter Developer
     picture: https://avatars.githubusercontent.com/u/19521054?v=4&s=200
     url: https://tech-andgar.me
-YTVideoId: DT4X_gCH-qs
+YTVideoId: BT2oZELyZK0
 ---
 
 Flutter is Google’s open-source UI toolkit for crafting beautiful, natively compiled applications for mobile, web, and desktop from a single codebase. Its fast development cycle, expressive UI, and strong performance make it ideal for startups and enterprises alike. Flutter’s widget-based architecture and hot reload feature empower developers to build and iterate quickly.


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Updated YouTube video ID for Flutter interview questions page