### PR TITLE
Fix sidebar collapsing while parsing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from "astro/config";
 import sitemap from '@astrojs/sitemap';
 import starlight from "@astrojs/starlight";
 import { isValidHttpsUrl } from "./src/helpers/utils.ts";
-import { sidebarConfig } from "./src/sidebar.config.ts";
+import { sidebarConfig, sidebarItems } from "./src/sidebar.config.ts";
 
 const port = process.env.port || 4300;
 const isProd = import.meta.env.PROD;
@@ -63,7 +63,7 @@ export default defineConfig({
           locale: "es",
         }
       },
-      sidebar: sidebarConfig,
+      sidebar: sidebarItems.parse(sidebarConfig),
       customCss: [
         './src/styles/custom.css',
       ],

--- a/src/sidebar.config.ts
+++ b/src/sidebar.config.ts
@@ -1,14 +1,17 @@
 import { z } from "astro/zod"
+import type { PartialSpecificKeys } from "./utils/types";
 
 const sidebarItem = z.object({
   label: z.string(),
   autogenerate: z.object({
     directory: z.string()
     }).optional(),
-  collapsed: z.boolean().default(true).optional(), 
+  collapsed: z.boolean().default(true), 
 })
 
-export type SidebarItem = z.infer<typeof sidebarItem>;
+export const sidebarItems = z.array(sidebarItem).default([])
+
+export type SidebarItem = PartialSpecificKeys<z.infer<typeof sidebarItem>, 'collapsed'>;
 
 export const sidebarConfig: readonly SidebarItem[] = [
   {

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -1,0 +1,1 @@
+export type PartialSpecificKeys<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/51b8002a-e89b-47af-94a5-acccee78c504)

After
![image](https://github.com/user-attachments/assets/1bfe89f5-1d46-49ab-a9b4-4f877785614b)

## Summary by Sourcery

Fix sidebar configuration to prevent unintended collapsing and improve type handling

Bug Fixes:
- Resolved issue with sidebar collapsing by adjusting Zod schema validation

Enhancements:
- Introduced a more flexible type definition for sidebar items
- Added a utility type to make specific keys optional