### PR TITLE
Add VideoDetail component and integrate into Mdx

### DIFF
--- a/src/components/VideoDetail.astro
+++ b/src/components/VideoDetail.astro
@@ -8,7 +8,12 @@ const { videoId } = Astro.props;
 <div class="video-detail">
   {videoId ? (
     <details>
-      <summary><span class="video-title">video <Icon class="youtube-icon" name="youtube" size="0.9rem"/></span></summary>
+      <summary role="button" aria-expanded="false">
+        <span class="video-title">
+          Watch on YouTube
+          <Icon class="youtube-icon" name="youtube" size="0.9rem"/>
+        </span>
+      </summary>
       <YouTubeEmbed videoId={videoId} />
     </details>
   ) : (

--- a/src/components/VideoDetail.astro
+++ b/src/components/VideoDetail.astro
@@ -1,0 +1,42 @@
+---
+import { Icon } from "@astrojs/starlight/components";
+import YouTubeEmbed from "./YouTubeEmbed.astro";
+
+const { videoId } = Astro.props;
+---
+
+<div class="video-detail">
+  {videoId ? (
+    <details>
+      <summary><span class="video-title">video <Icon class="youtube-icon" name="youtube" size="0.9rem"/></span></summary>
+      <YouTubeEmbed videoId={videoId} />
+    </details>
+  ) : (
+    <p>No video selected.</p>
+  )}
+</div>
+
+<style>
+  .video-detail {
+    margin: 1rem 0;
+  }
+
+  .video-detail summary {
+    cursor: pointer;
+    font-weight: bold;
+  }
+
+  .video-detail details[open] summary {
+    color: var(--sl-color-accent);
+  }
+
+  .video-title {
+    margin-top: 8px;
+    position: absolute;
+    font-size: 18px;
+  }
+
+  .youtube-icon {
+    display: inline-block !important;
+  }
+</style>

--- a/src/components/VideoDetail.astro
+++ b/src/components/VideoDetail.astro
@@ -1,6 +1,9 @@
 ---
 import { Icon } from "@astrojs/starlight/components";
 import YouTubeEmbed from "./YouTubeEmbed.astro";
+interface Props {
+  videoId: string;
+}
 
 const { videoId } = Astro.props;
 ---
@@ -41,7 +44,8 @@ const { videoId } = Astro.props;
     font-size: 18px;
   }
 
-  .youtube-icon {
-    display: inline-block !important;
+  .video-title .youtube-icon {
+    display: inline-block;
+    vertical-align: middle;
   }
 </style>

--- a/src/components/YouTubeEmbed.astro
+++ b/src/components/YouTubeEmbed.astro
@@ -46,6 +46,7 @@ youtubeUrl += params.toString();
 ---
 <div class="youtube-embed-container">
   <iframe
+    loading="lazy"
     src={youtubeUrl}
     title={title}
     frameborder="0"

--- a/src/components/YouTubeEmbed.astro
+++ b/src/components/YouTubeEmbed.astro
@@ -50,7 +50,7 @@ youtubeUrl += params.toString();
     src={youtubeUrl}
     title={title}
     frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen"
     referrerpolicy="strict-origin-when-cross-origin"
     allowfullscreen
   ></iframe>

--- a/src/content/docs/skills/Angular/index.mdx
+++ b/src/content/docs/skills/Angular/index.mdx
@@ -9,22 +9,21 @@ authors:
     url: https://signlanguagetech.com/
 YTVideoId: 1cqtZIKrryM
 ---
-import VideoDetail from "@components/VideoDetail.astro";
 
 Angular is a robust, full-featured framework maintained by Google for building scalable, high-performance web applications. With its powerful tools, modular architecture, and strong community support, Angular enables teams to develop complex single-page applications efficiently. Its features—such as two-way data binding, dependency injection, and a comprehensive CLI—make it a top choice for enterprise solutions and large-scale projects.
 
 ## Crucial Topics
 
-### What is the difference between component and directive? <VideoDetail videoId="rzrdBc6TMso" />
+### What is the difference between component and directive?
 Components are a type of directive with a template. Directives are used to add behavior to an existing DOM element.
 
-### What are types of directives? <VideoDetail videoId="wz6uQt6L_Mc" />
+### What are types of directives?
 There are three types of directives in Angular:
 1. Component Directives
 2. Structural Directives
 3. Attribute Directives
 
-### What are pipes? <VideoDetail videoId="7rAiyyM5pK8" />
+### What are pipes?
 Pipes are used to transform data in templates. They take in data as input and transform it to a desired output.
 
 ### One way vs two way bindings

--- a/src/content/docs/skills/Angular/index.mdx
+++ b/src/content/docs/skills/Angular/index.mdx
@@ -9,21 +9,22 @@ authors:
     url: https://signlanguagetech.com/
 YTVideoId: 1cqtZIKrryM
 ---
+import VideoDetail from "@components/VideoDetail.astro";
 
 Angular is a robust, full-featured framework maintained by Google for building scalable, high-performance web applications. With its powerful tools, modular architecture, and strong community support, Angular enables teams to develop complex single-page applications efficiently. Its features—such as two-way data binding, dependency injection, and a comprehensive CLI—make it a top choice for enterprise solutions and large-scale projects.
 
 ## Crucial Topics
 
-### What is the difference between component and directive?
+### What is the difference between component and directive? <VideoDetail videoId="rzrdBc6TMso" />
 Components are a type of directive with a template. Directives are used to add behavior to an existing DOM element.
 
-### What are types of directives?
+### What are types of directives? <VideoDetail videoId="wz6uQt6L_Mc" />
 There are three types of directives in Angular:
 1. Component Directives
 2. Structural Directives
 3. Attribute Directives
 
-### What are pipes?
+### What are pipes? <VideoDetail videoId="7rAiyyM5pK8" />
 Pipes are used to transform data in templates. They take in data as input and transform it to a desired output.
 
 ### One way vs two way bindings
@@ -100,7 +101,7 @@ Observables are unicast, while Subjects are multicast.
 - `Cold streams`: Emit values only when subscribed.
 - `Warm streams`: Emit values to current subscribers and cache the latest value for new subscribers.
 
-### How to unsubscribe?
+### How to unsubscribe? 
 Unsubscribe by calling the `unsubscribe` method on the subscription.
 
 ### Different unsubscribe approaches, should know pros and cons of each.

--- a/src/content/docs/skills/Angular/index.mdx
+++ b/src/content/docs/skills/Angular/index.mdx
@@ -100,7 +100,7 @@ Observables are unicast, while Subjects are multicast.
 - `Cold streams`: Emit values only when subscribed.
 - `Warm streams`: Emit values to current subscribers and cache the latest value for new subscribers.
 
-### How to unsubscribe? 
+### How to unsubscribe?
 Unsubscribe by calling the `unsubscribe` method on the subscription.
 
 ### Different unsubscribe approaches, should know pros and cons of each.


### PR DESCRIPTION
issue: #87

## Summary by Sourcery

Introduce a VideoDetail component to wrap and display YouTube videos in a collapsible details block, integrate it into the Angular MDX documentation for targeted topics, and improve YouTubeEmbed performance by adding lazy loading.

New Features:
- Add VideoDetail Astro component for collapsible YouTube video embeds with fallback messaging
- Embed Topic-specific videos in the Angular docs by integrating the VideoDetail component into MDX pages

Enhancements:
- Enable lazy loading on the YouTubeEmbed iframe