### PR TITLE
chore: Replace Surge action with pnpm command

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -58,6 +58,7 @@ jobs:
         id: deploy-surge
         run: |
           export DEPLOY_DOMAIN=${{ steps.preview-domain.outputs.domain }}
+          pnpm i surge
           pnpm exec surge --project ./dist --domain $DEPLOY_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
 
       # - name: Deploy to Surge for Preview

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -75,13 +75,15 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;         
             const urlPreview = ${{ steps.preview-domain.outputs.domain }};
 
             await github.rest.issues.createComment({
               owner,
               repo,
               issue_number,
-              body: `Preview URL is \`${urlPreview}\` has been successfully uploaded.`
+              body: `✅ Preview deployment URL is \`${urlPreview}\` has been successfully uploaded.`
             });
 
   teardown:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -56,15 +56,21 @@ jobs:
 
       - name: Deploy to Surge for Preview
         id: deploy-surge
-        uses: afc163/surge-preview@v1
-        with:
-          surge_token: ${{ secrets.SURGE_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: dist
-          build: echo "Skip build"  # Build already done in previous step
+        run: |
+          export DEPLOY_DOMAIN=${{ steps.preview-domain.outputs.domain }}"
+          pnpm exec surge --project ./dist --domain $DEPLOY_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
 
-      - name: Get Preview URL
-        run: echo "Preview URL is ${{ steps.deploy-surge.outputs.preview_url }}"
+      # - name: Deploy to Surge for Preview
+        # id: deploy-surge
+        # uses: afc163/surge-preview@v1
+        # with:
+        #   surge_token: ${{ secrets.SURGE_TOKEN }}
+        #   github_token: ${{ secrets.GITHUB_TOKEN }}
+        #   dist: dist
+        #   build: echo "Skip build"  # Build already done in previous step
+
+      # - name: Get Preview URL
+      #   run: echo "Preview URL is ${{ steps.deploy-surge.outputs.preview_url }}"
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -58,8 +58,7 @@ jobs:
         id: deploy-surge
         run: |
           export DEPLOY_DOMAIN=${{ steps.preview-domain.outputs.domain }}
-          pnpm i surge
-          pnpm exec surge --project ./dist --domain $DEPLOY_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
+          pnpm dlx surge --project ./dist --domain $DEPLOY_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
 
       # - name: Deploy to Surge for Preview
         # id: deploy-surge
@@ -71,7 +70,19 @@ jobs:
         #   build: echo "Skip build"  # Build already done in previous step
 
       - name: Get Preview URL
-        run: echo "Preview URL is ${{ steps.preview-domain.outputs.domain }}"
+        if: steps.deploy-surge.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const urlPreview = ${{ steps.preview-domain.outputs.domain }};
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: `Preview URL is \`${urlPreview}\` has been successfully uploaded.`
+            });
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -69,22 +69,40 @@ jobs:
         #   dist: dist
         #   build: echo "Skip build"  # Build already done in previous step
 
-      - name: Get Preview URL
+      - name: Comment on PR success
         if: steps.deploy-surge.outcome == 'success'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;         
-            const urlPreview = ${{ steps.preview-domain.outputs.domain }};
+            const issue_number = context.issue.number;
+            const domain = "${{ steps.preview-domain.outputs.domain }}";
 
             await github.rest.issues.createComment({
               owner,
               repo,
               issue_number,
-              body: `✅ Preview deployment URL is \`${urlPreview}\` has been successfully uploaded.`
+              body: `✅ Preview deployment \`${domain}\` has been successfully deleted.`
             });
+
+
+      # - name: Get Preview URL
+      #   if: steps.deploy-surge.outcome == 'success'
+      #   uses: actions/github-script@v7
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     script: |
+      #       const { owner, repo } = context.repo;
+      #       const issue_number = context.issue.number;         
+      #       const urlPreview = ${{ steps.preview-domain.outputs.domain }};
+
+      #       await github.rest.issues.createComment({
+      #         owner,
+      #         repo,
+      #         issue_number,
+      #         body: `✅ Preview deployment URL is \`${urlPreview}\` has been successfully uploaded.`
+      #       });
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -74,7 +74,7 @@ jobs:
                 owner,
                 repo,
                 issue_number,
-                body: `# ✅ Preview deployment URL
+                body: `## ✅ Preview deployment
             [https://${domain}](https://${domain})
             has been successfully uploaded.`,
               });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -60,15 +60,6 @@ jobs:
           export DEPLOY_DOMAIN=${{ steps.preview-domain.outputs.domain }}
           pnpm dlx surge --project ./dist --domain $DEPLOY_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
 
-      # - name: Deploy to Surge for Preview
-        # id: deploy-surge
-        # uses: afc163/surge-preview@v1
-        # with:
-        #   surge_token: ${{ secrets.SURGE_TOKEN }}
-        #   github_token: ${{ secrets.GITHUB_TOKEN }}
-        #   dist: dist
-        #   build: echo "Skip build"  # Build already done in previous step
-
       - name: Comment on PR success
         if: steps.deploy-surge.outcome == 'success'
         uses: actions/github-script@v7
@@ -83,7 +74,9 @@ jobs:
               owner,
               repo,
               issue_number,
-              body: `✅ Preview deployment URL \`https://${domain}\` has been successfully uploaded.`
+              body: `# ✅ Preview deployment URL 
+[\`https://${domain}\`](\`https://${domain}\`)
+has been successfully uploaded.`
             });
 
   teardown:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -75,8 +75,8 @@ jobs:
               repo,
               issue_number,
               body: `# ✅ Preview deployment URL 
-[\`https://${domain}\`](\`https://${domain}\`)
-has been successfully uploaded.`
+[https://${domain}](https://${domain})
+has been successfully uploaded.`,
             });
 
   teardown:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -83,26 +83,8 @@ jobs:
               owner,
               repo,
               issue_number,
-              body: `✅ Preview deployment \`${domain}\` has been successfully deleted.`
+              body: `✅ Preview deployment URL \`https://${domain}\` has been successfully uploaded.`
             });
-
-
-      # - name: Get Preview URL
-      #   if: steps.deploy-surge.outcome == 'success'
-      #   uses: actions/github-script@v7
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     script: |
-      #       const { owner, repo } = context.repo;
-      #       const issue_number = context.issue.number;         
-      #       const urlPreview = ${{ steps.preview-domain.outputs.domain }};
-
-      #       await github.rest.issues.createComment({
-      #         owner,
-      #         repo,
-      #         issue_number,
-      #         body: `✅ Preview deployment URL is \`${urlPreview}\` has been successfully uploaded.`
-      #       });
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Deploy to Surge for Preview
         id: deploy-surge
         run: |
-          export DEPLOY_DOMAIN=${{ steps.preview-domain.outputs.domain }}"
+          export DEPLOY_DOMAIN=${{ steps.preview-domain.outputs.domain }}
           pnpm exec surge --project ./dist --domain $DEPLOY_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
 
       # - name: Deploy to Surge for Preview
@@ -69,8 +69,8 @@ jobs:
         #   dist: dist
         #   build: echo "Skip build"  # Build already done in previous step
 
-      # - name: Get Preview URL
-      #   run: echo "Preview URL is ${{ steps.deploy-surge.outputs.preview_url }}"
+      - name: Get Preview URL
+        run: echo "Preview URL is ${{ steps.preview-domain.outputs.domain }}"
 
   teardown:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -71,14 +71,13 @@ jobs:
             const domain = "${{ steps.preview-domain.outputs.domain }}";
 
             await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number,
-              body: `# ✅ Preview deployment URL 
-[https://${domain}](https://${domain})
-has been successfully uploaded.`,
-            });
-
+                owner,
+                repo,
+                issue_number,
+                body: `# ✅ Preview deployment URL
+            [https://${domain}](https://${domain})
+            has been successfully uploaded.`,
+              });
   teardown:
     runs-on: ubuntu-latest
     if: github.event.action == 'closed'


### PR DESCRIPTION
## Summary by Sourcery

Update the GitHub Actions preview workflow to deploy using the Surge CLI via pnpm instead of the afc163/surge-preview action

Enhancements:
- Replace the afc163/surge-preview action with a manual `pnpm exec surge` command that uses the domain from the preview-domain step
- Comment out the old deploy-surge and Get Preview URL steps to remove the previous action-based deployment