### PR TITLE
ci: Scope workflow jobs to pull requests

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   preview:
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -80,7 +80,7 @@ jobs:
               });
   teardown:
     runs-on: ubuntu-latest
-    if: github.event.action == 'closed'
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
     steps:
       - name: Generate preview domain
         id: preview-domain
@@ -149,7 +149,7 @@ jobs:
 
   delete-branch:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     steps:
       - name: Delete branch
         id: delete-branch


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add explicit `github.event_name == 'pull_request'` checks to the preview, teardown, and delete-branch jobs to scope them to pull request events.