### PR TITLE
ci: Switch preview workflow to pull_request_target

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,8 +1,10 @@
 name: PR Preview
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, closed]
+    # With pull_request_target, this checks out the PR's code.
+    # Ensure you trust the code or understand the security implications.
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Switch preview workflow trigger from pull_request to pull_request_target and add comments warning about trusting PR code